### PR TITLE
Fixing Pod name on installation instructions for Cocoapods

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Installation
 
 **Cocoapods**
 
-<code>pod 'DateTools'</code>
+<code>pod 'Pluralize.swift'</code>
 
 in code then
 


### PR DESCRIPTION
Instructions for installation via Cocoapods was pointing to the wrong Pod: `pod 'DateTools'`.
