### PR TITLE
sharedInstance should not be a computed property. It prevents custom …

### DIFF
--- a/Pluralize/Pluralize.swift
+++ b/Pluralize/Pluralize.swift
@@ -160,9 +160,7 @@ public class Pluralize {
         sharedInstance.unchanging(word: word)
     }
 
-    class var sharedInstance : Pluralize {
-        return Pluralize()
-    }
+    static var sharedInstance = Pluralize()
 
     private class func regexReplace(input: String, pattern: String, template: String) -> String {
         let regex = try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)

--- a/PluralizeTests/PluralizeTests.swift
+++ b/PluralizeTests/PluralizeTests.swift
@@ -183,4 +183,16 @@ class PluralizeTests: XCTestCase {
             XCTAssertEqual(singular.pluralize(), plural, "Plural of \(singular) should be \(plural)")
         }
     }
+  
+    func testAddingRules() {
+        let singular = "word"
+        let plural = "words"
+        Pluralize.add(rule: singular, with: plural)
+        XCTAssertEqual(singular.pluralize(), plural, "Plural of \(singular) should be \(plural)")
+      
+        // Override rule with another rule
+        let overridingPlural = "wordies"
+        Pluralize.add(rule: singular, with: overridingPlural)
+        XCTAssertEqual(singular.pluralize(), overridingPlural, "Plural of \(singular) should be \(overridingPlural)")
+    }
 }


### PR DESCRIPTION
…rules from persisting. Fixes #17 
