### PR TITLE
Bump version to 2.0

### DIFF
--- a/Pluralize.swift.podspec
+++ b/Pluralize.swift.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "Pluralize.swift"
-  s.version          = "1.0"
+  s.version          = "2.0"
   s.summary          = "Great Swift String Pluralize Extension"
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
This bumps the version to 2.0, which supports Swift 3. 

After merging this PR, please create a 2.0 tag:

```
cd Pluralize.swift/
git checkout master
git pull origin master
git tag 2.0
git push origin 2.0
```

Then, send an update to CocoaPods, that way we can just run `pod update Pluralize.swift` and get all of the Swift 4 goodies:

```
pod trunk push
```

Thanks a lot!